### PR TITLE
Refactor central application logging

### DIFF
--- a/App/include/ApplicationViewState.h
+++ b/App/include/ApplicationViewState.h
@@ -23,6 +23,7 @@ along with this program.  If not, see https://www.gnu.org/licenses/.
 #pragma once
 
 #include "../JuceLibraryCode/JuceHeader.h"
+#include "Logging.h"
 #include "juce_graphics/juce_graphics.h"
 
 namespace IDs
@@ -336,11 +337,11 @@ public:
         auto xmlToWrite = m_applicationStateValueTree.createXml();
         if (xmlToWrite->writeTo(settingsFile))
         {
-            std::cout << "settings written to: " + settingsFile.getFullPathName() << std::endl;
+            NS_LOG_INFO(project, "settings written: " + settingsFile.getFullPathName());
         }
         else
         {
-            std::cout << "couldn't write to: " + settingsFile.getFullPathName() << std::endl;
+            NS_LOG_ERROR(project, "failed to write settings: " + settingsFile.getFullPathName());
         }
     }
 

--- a/App/include/EditComponent.h
+++ b/App/include/EditComponent.h
@@ -164,7 +164,7 @@ private:
                                     auto newStartBeat = tracktion::BeatPosition::fromBeats(clipStartBeat);
                                     auto newLength = note->getEndBeat() - newStartBeat;
                                     note->setStartAndLength(newStartBeat, newLength, &um);
-                                    GUIHelpers::log("Attention: note start corrected!");
+                                    NS_LOG_WARN(edit, "corrected MIDI note start before clip boundary");
                                 }
                             }
                         }

--- a/App/include/Logging.h
+++ b/App/include/Logging.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "../JuceLibraryCode/JuceHeader.h"
+
+namespace NextStudio::Logging
+{
+enum class Level
+{
+    debug,
+    info,
+    warn,
+    error
+};
+
+enum class Category
+{
+    app,
+    ui,
+    viewstate,
+    selection,
+    workflow,
+    project,
+    edit,
+    plugins,
+    filesystem,
+    autosave,
+    transport,
+    engine,
+    setup
+};
+
+void log(Level level, Category category, const juce::String &message, const char *file = nullptr, int line = 0);
+
+const char *toString(Level level);
+const char *toString(Category category);
+
+inline juce::String toLogString(const juce::String &value) { return value; }
+inline juce::String toLogString(const char *value) { return value != nullptr ? juce::String(value) : juce::String("<null>"); }
+inline juce::String toLogString(const std::string &value) { return juce::String(value); }
+inline juce::String toLogString(bool value) { return value ? "true" : "false"; }
+
+template <typename T>
+inline juce::String toLogString(const T &value)
+{
+    return juce::String(value);
+}
+} // namespace NextStudio::Logging
+
+#define NS_LOG_DEBUG(category, message) NextStudio::Logging::log(NextStudio::Logging::Level::debug, NextStudio::Logging::Category::category, (message), __FILE__, __LINE__)
+#define NS_LOG_INFO(category, message) NextStudio::Logging::log(NextStudio::Logging::Level::info, NextStudio::Logging::Category::category, (message), __FILE__, __LINE__)
+#define NS_LOG_WARN(category, message) NextStudio::Logging::log(NextStudio::Logging::Level::warn, NextStudio::Logging::Category::category, (message), __FILE__, __LINE__)
+#define NS_LOG_ERROR(category, message) NextStudio::Logging::log(NextStudio::Logging::Level::error, NextStudio::Logging::Category::category, (message), __FILE__, __LINE__)

--- a/App/include/MainComponent.h
+++ b/App/include/MainComponent.h
@@ -120,7 +120,7 @@ private:
 
     void updateTheme()
     {
-        GUIHelpers::log("update theme");
+        NS_LOG_DEBUG(viewstate, "updating application theme");
         ThemeHelpers::applyLookAndFeelColours(getLookAndFeel(), m_applicationState);
         if (m_editComponent)
             m_editComponent->updateButtonIcons();

--- a/App/include/RenderDialog.h
+++ b/App/include/RenderDialog.h
@@ -301,18 +301,18 @@ private:
     {
         if (button == &m_startButton)
         {
-            GUIHelpers::log(getRenderFile().getFullPathName());
+            NS_LOG_INFO(filesystem, "render requested: " + getRenderFile().getFullPathName());
             if (getRenderFile().isDirectory())
             {
-                GUIHelpers::log("no file choosen!");
+                NS_LOG_WARN(filesystem, "render aborted: no output file selected");
                 return;
             }
             if (getRenderFile().existsAsFile())
             {
-                GUIHelpers::log("an existing file is choosen");
+                NS_LOG_WARN(filesystem, "render aborted: output file already exists");
                 return;
             }
-            GUIHelpers::log("this is a new created file");
+            NS_LOG_DEBUG(filesystem, "render output path is new and writable candidate");
             EngineHelpers::renderEditToFile(m_evs, getRenderFile(), getTimeRange());
         }
     }

--- a/App/include/TrackHeadComponent.h
+++ b/App/include/TrackHeadComponent.h
@@ -122,7 +122,7 @@ public:
         int index = getIndexAtPosition(e.getPosition());
         if (index >= 0 && index < (int)m_colours.size())
         {
-            std::cout << "FARBINEDX: " << index << std::endl;
+            NS_LOG_DEBUG(ui, "track colour selected: index=" + juce::String(index));
             m_track->setColour(m_colours[index]);
             m_selectedIndex = index;
             getParentComponent()->exitModalState(3000 + index);

--- a/App/include/TrackPresetAdapter.h
+++ b/App/include/TrackPresetAdapter.h
@@ -419,7 +419,7 @@ protected:
             auto tempPlugin = m_track.edit.engine.getPluginManager().createNewPlugin(m_track.edit, stateCopy);
             if (tempPlugin == nullptr)
             {
-                GUIHelpers::log("TrackPresetAdapter: Failed to create plugin from preset state for track '" + m_track.getName() + "'.");
+                NS_LOG_ERROR(plugins, "failed to create plugin from preset state for track '" + m_track.getName() + "'");
                 return false;
             }
 
@@ -527,7 +527,7 @@ protected:
         std::vector<PreparedPluginState> prepared;
         if (!collectPreparedPluginStates(state, prepared) || !validator(prepared))
         {
-            GUIHelpers::log(context + ": Rejected incompatible track preset for track '" + getTrack().getName() + "'.");
+            NS_LOG_WARN(plugins, context + ": rejected incompatible track preset for track '" + getTrack().getName() + "'");
             return false;
         }
 

--- a/App/include/Utilities.h
+++ b/App/include/Utilities.h
@@ -28,6 +28,7 @@ along with this program.  If not, see https://www.gnu.org/licenses/.
 #include "ThumbNailManager.h"
 #include "ProjectLifecycle.h"
 #include "ClipPropertyEdit.h"
+#include "Logging.h"
 #include "juce_gui_basics/juce_gui_basics.h"
 
 namespace te = tracktion_engine;
@@ -172,15 +173,11 @@ float getZoomScaleFactor(int delta, float unitDistance);
 
 template <typename T> void log(T message)
 {
-#ifdef DEBUG_OR_RELWITHDEBINFO
-    std::cout << juce::Time::getCurrentTime().toString(true, true, true, true) << ": " << message << std::endl;
-#endif
+    NS_LOG_DEBUG(ui, NextStudio::Logging::toLogString(message));
 }
 template <typename T> void log(const juce::String &d, T message)
 {
-#ifdef DEBUG_OR_RELWITHDEBINFO
-    std::cout << juce::Time::getCurrentTime().toString(true, true, true, true) << ": " << d << " : " << ": " << message << std::endl;
-#endif
+    NS_LOG_DEBUG(ui, d + " : " + NextStudio::Logging::toLogString(message));
 }
 
 // void centerView(EditViewState& evs);

--- a/App/src/Browser_Base.cpp
+++ b/App/src/Browser_Base.cpp
@@ -33,7 +33,7 @@ PathComponent::PathComponent(juce::File dir, ApplicationViewState &appState)
     addAndMakeVisible(m_button);
     m_button.onClick = [this]
     {
-        GUIHelpers::log("button");
+        NS_LOG_DEBUG(ui, "browser path up button pressed");
         setDir(m_currentPath.getParentDirectory());
     };
     m_currentPathField.setColour(juce::TextEditor::ColourIds::backgroundColourId, m_appState.getBackgroundColour1());

--- a/App/src/DrumPadComponent.cpp
+++ b/App/src/DrumPadComponent.cpp
@@ -80,7 +80,7 @@ void PadComponent::mouseUp(const juce::MouseEvent &e)
             // Always use the pad's fixed midiNote - simplified logic!
             int midiNote = owner->getMidiNoteForPad(padIndex);
 
-            GUIHelpers::log("DrumPad::mouseUp: Using fixed MIDI note " + juce::String(midiNote) + " for padIndex " + juce::String(padIndex));
+            NS_LOG_DEBUG(engine, "drum pad mouse-up sends fixed MIDI note " + juce::String(midiNote) + " for pad " + juce::String(padIndex));
 
             virMidiIn->handleIncomingMidiMessage(juce::MidiMessage::noteOff(1, midiNote, .8f), 0);
         }
@@ -133,7 +133,7 @@ DrumPadGridComponent::DrumPadGridComponent(te::SamplerPlugin &plugin, Applicatio
       m_samplerPlugin(plugin),
       m_appViewState(appViewState)
 {
-    GUIHelpers::log("DrumPadComponent: constructor");
+    NS_LOG_DEBUG(plugins, "DrumPadGridComponent constructed");
 
     m_samplerPlugin.state.addListener(this);
 
@@ -152,7 +152,7 @@ DrumPadGridComponent::DrumPadGridComponent(te::SamplerPlugin &plugin, Applicatio
 
 DrumPadGridComponent::~DrumPadGridComponent()
 {
-    GUIHelpers::log("DrumPadComponent: destructor");
+    NS_LOG_DEBUG(plugins, "DrumPadGridComponent destroyed");
 
     cleanupMidiInputDevices();
 
@@ -226,33 +226,33 @@ void DrumPadGridComponent::buttonDown(int padIndex)
         int soundIndex = getSoundIndexForPad(padIndex);
 
         // Always play sound when clicked, regardless of whether it has media
-        GUIHelpers::log("DrumPadComponent: Clicked pad " + juce::String(padIndex) + ", soundIndex: " + juce::String(soundIndex));
+        NS_LOG_INFO(ui, "drum pad clicked: pad=" + juce::String(padIndex) + ", soundIndex=" + juce::String(soundIndex));
 
         // Check if this pad has a valid sound
         if (soundIndex < m_samplerPlugin.getNumSounds())
         {
             auto soundName = m_samplerPlugin.getSoundName(soundIndex);
-            GUIHelpers::log("DrumPadComponent: Sound at soundIndex " + juce::String(soundIndex) + ": " + soundName);
+            NS_LOG_DEBUG(plugins, "drum pad sound resolved: index=" + juce::String(soundIndex) + ", name=" + soundName);
 
             if (!soundName.isEmpty() && soundName != "Empty")
             {
                 // Always use the pad's fixed midiNote - no more complex fallback logic!
                 int midiNote = getMidiNoteForPad(padIndex);
 
-                GUIHelpers::log("DrumPadComponent: Using fixed MIDI note " + juce::String(midiNote) + " for padIndex " + juce::String(padIndex));
+                NS_LOG_DEBUG(engine, "drum pad uses fixed MIDI note " + juce::String(midiNote) + " for pad " + juce::String(padIndex));
 
                 if (auto virMidiIn = EngineHelpers::getVirtualMidiInputDevice(*getEdit()))
                     virMidiIn->handleIncomingMidiMessage(juce::MidiMessage::noteOn(1, midiNote, .8f), 0);
-                GUIHelpers::log("DrumPadComponent: Playing note " + juce::String(midiNote));
+                NS_LOG_INFO(engine, "drum pad triggered note " + juce::String(midiNote));
             }
             else
             {
-                GUIHelpers::log("DrumPadComponent: No valid sound at soundIndex " + juce::String(soundIndex));
+                NS_LOG_WARN(plugins, "drum pad has no valid sound at index " + juce::String(soundIndex));
             }
         }
         else
         {
-            GUIHelpers::log("DrumPadComponent: Sound index " + juce::String(soundIndex) + " out of range");
+            NS_LOG_WARN(plugins, "drum pad sound index out of range: " + juce::String(soundIndex));
         }
 
         // Visual feedback
@@ -263,14 +263,14 @@ void DrumPadGridComponent::buttonDown(int padIndex)
 
 void DrumPadGridComponent::showPadContextMenu(int padIndex)
 {
-    GUIHelpers::log("DrumPadComponent: Right click on pad " + juce::String(padIndex));
+    NS_LOG_DEBUG(ui, "drum pad context menu opened for pad " + juce::String(padIndex));
 
     juce::PopupMenu menu;
     menu.addItem("Load Sample",
                  [this, padIndex]()
                  {
                      int soundIndex = getSoundIndexForPad(padIndex);
-                     GUIHelpers::log("DrumPadComponent: Opening file chooser for pad " + juce::String(padIndex) + " (soundIndex: " + juce::String(soundIndex) + ")");
+                     NS_LOG_INFO(filesystem, "opening sample chooser for pad " + juce::String(padIndex) + ", soundIndex=" + juce::String(soundIndex));
 
                      auto fc = std::make_shared<juce::FileChooser>("Select a sample to load", juce::File(), "*.wav;*.aif;*.aiff");
 
@@ -284,7 +284,7 @@ void DrumPadGridComponent::showPadContextMenu(int padIndex)
 
                                          if (fc.getResults().isEmpty())
                                          {
-                                             GUIHelpers::log("DrumPadComponent: File selection cancelled");
+                                             NS_LOG_DEBUG(filesystem, "sample chooser cancelled for drum pad");
                                              return;
                                          }
 
@@ -299,7 +299,7 @@ void DrumPadGridComponent::showPadContextMenu(int padIndex)
                  [this, padIndex]()
                  {
                      int soundIndex = getSoundIndexForPad(padIndex);
-                     GUIHelpers::log("DrumPadComponent: Clearing pad " + juce::String(padIndex) + " (soundIndex: " + juce::String(soundIndex) + ")");
+                     NS_LOG_INFO(plugins, "clearing drum pad " + juce::String(padIndex) + ", soundIndex=" + juce::String(soundIndex));
 
                      if (soundIndex < m_samplerPlugin.getNumSounds())
                      {
@@ -312,7 +312,7 @@ void DrumPadGridComponent::showPadContextMenu(int padIndex)
                          m_samplerPlugin.setSoundParams(soundIndex, padMidiNote, padMidiNote, padMidiNote);
                          m_samplerPlugin.setSoundOpenEnded(soundIndex, true);
 
-                         GUIHelpers::log("DrumPadComponent: Cleared sound at index " + juce::String(soundIndex) + " (pad midiNote: " + juce::String(padMidiNote) + ")");
+                         NS_LOG_INFO(plugins, "cleared drum pad sound at index " + juce::String(soundIndex) + ", midiNote=" + juce::String(padMidiNote));
 
                          updatePadNames();
 
@@ -364,7 +364,7 @@ void DrumPadGridComponent::valueTreePropertyChanged(juce::ValueTree &, const juc
 
 void DrumPadGridComponent::updatePadNames()
 {
-    GUIHelpers::log("DrumPadComponent: updatePadNames - " + juce::String(m_samplerPlugin.getNumSounds()) + " sounds available");
+    NS_LOG_DEBUG(plugins, "updating drum pad names; sounds available=" + juce::String(m_samplerPlugin.getNumSounds()));
 
     for (int i = 0; i < m_pads.size(); ++i)
     {
@@ -376,7 +376,7 @@ void DrumPadGridComponent::updatePadNames()
                 m_pads[i]->setText("+");
             else
                 m_pads[i]->setText(soundName);
-            GUIHelpers::log("DrumPadComponent: Pad " + juce::String(i) + " (sound " + juce::String(soundIndex) + ") name: " + soundName);
+            NS_LOG_DEBUG(plugins, "drum pad label updated: pad=" + juce::String(i) + ", soundIndex=" + juce::String(soundIndex) + ", name=" + soundName);
         }
         else
         {
@@ -468,7 +468,7 @@ void DrumPadGridComponent::itemDropped(const SourceDetails &dragSourceDetails)
             if (padIndex != -1)
             {
                 int soundIndex = getSoundIndexForPad(padIndex);
-                GUIHelpers::log("DrumPadComponent: Dropped file " + f.getFileName() + " on pad " + juce::String(padIndex) + " (soundIndex: " + juce::String(soundIndex) + ")");
+                NS_LOG_INFO(filesystem, "sample dropped on drum pad: file=" + f.getFileName() + ", pad=" + juce::String(padIndex) + ", soundIndex=" + juce::String(soundIndex));
                 setupNewSample(soundIndex, f);
             }
         }
@@ -504,7 +504,7 @@ void DrumPadGridComponent::startPadDrag(int sourcePadIndex, const juce::MouseEve
     if (soundName.isEmpty() || soundName == "Empty")
         return;
 
-    GUIHelpers::log("DrumPadComponent: Starting drag from pad " + juce::String(sourcePadIndex) + " (sound: " + soundName + ")");
+    NS_LOG_DEBUG(ui, "starting drum pad drag: pad=" + juce::String(sourcePadIndex) + ", sound=" + soundName);
 
     m_isPadDragging = true;
     m_dragSourcePad = sourcePadIndex;
@@ -611,7 +611,7 @@ void DrumPadGridComponent::endPadDrag(const juce::MouseEvent &event)
     if (!m_isPadDragging)
         return;
 
-    GUIHelpers::log("DrumPadComponent: Ending drag from pad " + juce::String(m_dragSourcePad));
+    NS_LOG_DEBUG(ui, "ending drum pad drag from pad " + juce::String(m_dragSourcePad));
 
     // Check which pad we're dropping on - use same logic as continuePadDrag
     auto globalPos = event.getScreenPosition();
@@ -629,7 +629,7 @@ void DrumPadGridComponent::endPadDrag(const juce::MouseEvent &event)
 
     if (targetPadIndex >= 0 && targetPadIndex != m_dragSourcePad)
     {
-        GUIHelpers::log("DrumPadComponent: Dropping on pad " + juce::String(targetPadIndex));
+        NS_LOG_INFO(ui, "dropping drum pad onto target pad " + juce::String(targetPadIndex));
         swapPadSounds(m_dragSourcePad, targetPadIndex);
 
         // Visual feedback on successful drop
@@ -678,7 +678,7 @@ void DrumPadGridComponent::swapPadSounds(int sourcePad, int targetPad)
     int sourceSoundIdx = getSoundIndexForPad(sourcePad);
     int targetSoundIdx = getSoundIndexForPad(targetPad);
 
-    GUIHelpers::log("DrumPadComponent: Swapping sounds " + juce::String(sourceSoundIdx) + " <-> " + juce::String(targetSoundIdx));
+    NS_LOG_INFO(plugins, "swapping drum pad sounds " + juce::String(sourceSoundIdx) + " <-> " + juce::String(targetSoundIdx));
 
     // 1. Read status directly from the plugin (Single Source of Truth)
     auto stateA = getSoundStateFromPlugin(sourceSoundIdx);
@@ -713,7 +713,7 @@ void DrumPadGridComponent::swapPadSounds(int sourcePad, int targetPad)
 
 void DrumPadGridComponent::setupMidiInputDevices()
 {
-    GUIHelpers::log("DrumPadComponent: Setting up MIDI input devices");
+    NS_LOG_DEBUG(engine, "setting up drum pad MIDI input devices");
 
     auto &deviceManager = m_edit.engine.getDeviceManager();
 
@@ -721,16 +721,16 @@ void DrumPadGridComponent::setupMidiInputDevices()
     deviceManager.rescanMidiDeviceList();
 
     auto midiDevices = deviceManager.getMidiInDevices();
-    GUIHelpers::log("DrumPadComponent: Found " + juce::String(midiDevices.size()) + " MIDI input devices");
+    NS_LOG_INFO(engine, "found " + juce::String(midiDevices.size()) + " MIDI input devices for drum pads");
 
     for (int i = 0; i < midiDevices.size(); ++i)
     {
         auto &device = midiDevices[i];
-        GUIHelpers::log("DrumPadComponent: Device " + juce::String(i) + ": " + device->getName() + " (Type: " + juce::String(device->getDeviceType()) + ")");
+        NS_LOG_DEBUG(engine, "MIDI device " + juce::String(i) + ": " + device->getName() + " (type=" + juce::String(device->getDeviceType()) + ")");
 
         if (auto physicalDevice = dynamic_cast<te::PhysicalMidiInputDevice *>(device.get()))
         {
-            GUIHelpers::log("DrumPadComponent: Found physical MIDI device: " + physicalDevice->getName());
+            NS_LOG_DEBUG(engine, "physical MIDI device available: " + physicalDevice->getName());
 
             // Enable the device and add as listener
             physicalDevice->setEnabled(true);
@@ -741,39 +741,39 @@ void DrumPadGridComponent::setupMidiInputDevices()
             auto error = physicalDevice->openDevice();
             if (!error.isEmpty())
             {
-                GUIHelpers::log("DrumPadComponent: Error opening MIDI device " + physicalDevice->getName() + ": " + error);
+                NS_LOG_ERROR(engine, "failed to open MIDI device " + physicalDevice->getName() + ": " + error);
             }
             else
             {
-                GUIHelpers::log("DrumPadComponent: Successfully connected to MIDI device: " + physicalDevice->getName());
+                NS_LOG_INFO(engine, "connected drum pads to MIDI device: " + physicalDevice->getName());
             }
         }
         else
         {
-            GUIHelpers::log("DrumPadComponent: Device " + device->getName() + " is not a physical MIDI device");
+            NS_LOG_DEBUG(engine, "ignoring non-physical MIDI device: " + device->getName());
         }
     }
 
     if (m_connectedMidiDevices.isEmpty())
     {
-        GUIHelpers::log("DrumPadComponent: No physical MIDI devices found - pad lighting will only work with virtual MIDI");
+        NS_LOG_WARN(engine, "no physical MIDI devices found; drum pad lighting will rely on virtual MIDI only");
     }
     else
     {
-        GUIHelpers::log("DrumPadComponent: Connected to " + juce::String(m_connectedMidiDevices.size()) + " MIDI devices");
+        NS_LOG_INFO(engine, "connected drum pads to " + juce::String(m_connectedMidiDevices.size()) + " MIDI devices");
     }
 }
 
 void DrumPadGridComponent::cleanupMidiInputDevices()
 {
-    GUIHelpers::log("DrumPadComponent: Cleaning up MIDI input devices");
+    NS_LOG_DEBUG(engine, "cleaning up drum pad MIDI input devices");
 
     for (auto *device : m_connectedMidiDevices)
     {
         if (device != nullptr)
         {
             device->removeListener(this);
-            GUIHelpers::log("DrumPadComponent: Disconnected from MIDI device: " + device->getName());
+            NS_LOG_DEBUG(engine, "disconnected drum pads from MIDI device: " + device->getName());
         }
     }
 
@@ -792,7 +792,7 @@ void DrumPadGridComponent::handleIncomingMidiMessage(const juce::MidiMessage &me
         {
             if (message.isNoteOn())
             {
-                GUIHelpers::log("MIDI Note ON: " + juce::String(message.getNoteNumber()));
+                NS_LOG_DEBUG(engine, "incoming drum pad MIDI note-on: " + juce::String(message.getNoteNumber()));
             }
 
             processMidiForPadLighting(message);
@@ -863,11 +863,11 @@ int DrumPadGridComponent::getPadIndexForMidiNote(int midiNote)
     if (midiNote >= BASE_MIDI_NOTE && midiNote < BASE_MIDI_NOTE + 16)
     {
         int padIndex = midiNote - BASE_MIDI_NOTE;
-        GUIHelpers::log("DrumPadComponent: Direct mapping - MIDI note " + juce::String(midiNote) + " -> pad index " + juce::String(padIndex));
+        NS_LOG_DEBUG(engine, "drum pad direct MIDI mapping: note " + juce::String(midiNote) + " -> pad " + juce::String(padIndex));
         return padIndex;
     }
 
-    GUIHelpers::log("DrumPadComponent: MIDI note " + juce::String(midiNote) + " out of range");
+    NS_LOG_DEBUG(engine, "drum pad MIDI note out of range: " + juce::String(midiNote));
     return -1; // No pad found for this note
 }
 
@@ -883,7 +883,7 @@ void DrumPadGridComponent::setupNewSample(int soundIndex, const juce::File &file
     // Ensure we have enough sound slots in the sampler
     while (m_samplerPlugin.getNumSounds() <= soundIndex)
     {
-        GUIHelpers::log("DrumPadComponent: Adding empty sound slot at index " + juce::String(m_samplerPlugin.getNumSounds()));
+        NS_LOG_DEBUG(plugins, "adding empty drum sampler sound slot at index " + juce::String(m_samplerPlugin.getNumSounds()));
         m_samplerPlugin.addSound({}, "Empty", 0, 0, 0);
     }
 

--- a/App/src/DrumSamplerView.cpp
+++ b/App/src/DrumSamplerView.cpp
@@ -7,12 +7,12 @@ DrumSamplerView::DrumSamplerView(EditViewState &evs, te::SamplerPlugin &sampler)
       m_drumPadComponent(sampler, evs.m_applicationState),
       m_soundEditorPanel(sampler, sampler.edit, evs.m_applicationState)
 {
-    GUIHelpers::log("DrumSamplerView: constructor");
+    NS_LOG_DEBUG(plugins, "DrumSamplerView constructed");
 
     // Ensure the sampler has the expected 16 sounds if it's currently empty
     if (m_sampler.getNumSounds() == 0)
     {
-        GUIHelpers::log("DrumSamplerView: Sampler is empty, applying factory default state.");
+        NS_LOG_INFO(plugins, "drum sampler empty; applying factory default state");
         restorePluginState(getFactoryDefaultState());
     }
 
@@ -44,7 +44,7 @@ DrumSamplerView::DrumSamplerView(EditViewState &evs, te::SamplerPlugin &sampler)
     }
 }
 
-DrumSamplerView::~DrumSamplerView() { GUIHelpers::log("DrumSamplerView: destructor"); }
+DrumSamplerView::~DrumSamplerView() { NS_LOG_DEBUG(plugins, "DrumSamplerView destroyed"); }
 
 void DrumSamplerView::paint(juce::Graphics &g) { g.fillAll(m_editViewState.m_applicationState.getBackgroundColour1().darker()); }
 

--- a/App/src/EditComponent.cpp
+++ b/App/src/EditComponent.cpp
@@ -44,7 +44,7 @@ void rewriteAutoSaveSourcePaths(juce::ValueTree node, te::Edit &edit, const juce
             }
             else
             {
-                GUIHelpers::log("WARNING: Source file not found during autosave: " + absoluteSourceFile.getFullPathName());
+                NS_LOG_WARN(autosave, "source file missing during autosave rewrite: " + absoluteSourceFile.getFullPathName());
             }
         }
     }
@@ -330,7 +330,7 @@ void EditComponent::paintOverChildren(juce::Graphics &g)
 
 void EditComponent::resized()
 {
-    GUIHelpers::log("EditComponent: resized()");
+    NS_LOG_DEBUG(ui, "EditComponent resized");
     m_automationToolBar.setBounds(getAutomationToolBarRect());
     m_toolBar.setBounds(getToolBarRect());
     m_clipPropertiesBar.setBounds(getClipPropertiesRect());
@@ -547,7 +547,7 @@ void EditComponent::saveTempFile()
 
     if (!m_editViewState.m_needAutoSave)
     {
-        GUIHelpers::log("Edit is up to date, no autosave needed.");
+        NS_LOG_DEBUG(autosave, "autosave skipped; edit already up to date");
         return;
     }
 
@@ -578,7 +578,7 @@ void EditComponent::saveTempFile()
     catch (const std::exception &e)
     {
         m_autoSaveInProgress = false;
-        GUIHelpers::log("ERROR: Exception during autosave process: " + juce::String(e.what()));
+        NS_LOG_ERROR(autosave, "exception during autosave process: " + juce::String(e.what()));
     }
 }
 
@@ -604,7 +604,7 @@ void EditComponent::queueTempFileWrite(juce::ValueTree editStateCopy, const juce
             }
             catch (const std::exception &e)
             {
-                GUIHelpers::log("ERROR: Exception during autosave write: " + juce::String(e.what()));
+                NS_LOG_ERROR(autosave, "exception during autosave write: " + juce::String(e.what()));
             }
 
             juce::MessageManager::callAsync(
@@ -622,7 +622,7 @@ void EditComponent::handleTempFileWriteFinished(bool wasSuccessful, juce::uint64
 
     if (wasSuccessful)
     {
-        GUIHelpers::log("Autosave successful: " + targetTempFile.getFullPathName());
+        NS_LOG_INFO(autosave, "autosave successful: " + targetTempFile.getFullPathName());
 
         // Only clear the dirty flag when the written snapshot still matches the latest edit state.
         if (generation == m_autoSaveGeneration.load())
@@ -630,7 +630,7 @@ void EditComponent::handleTempFileWriteFinished(bool wasSuccessful, juce::uint64
     }
     else
     {
-        GUIHelpers::log("ERROR: Autosave failed to write to file: " + targetTempFile.getFullPathName());
+        NS_LOG_ERROR(autosave, "autosave failed to write file: " + targetTempFile.getFullPathName());
     }
 
     if (m_autoSaveQueued.exchange(false))
@@ -694,7 +694,7 @@ void EditComponent::valueTreeChildAdded(juce::ValueTree &parent, juce::ValueTree
     }
     if (c.hasType(te::IDs::AUTOMATIONCURVE))
     {
-        GUIHelpers::log(c.toXmlString());
+        NS_LOG_DEBUG(edit, "automation curve added\n" + c.toXmlString());
         markAndUpdate(m_updateTracks);
         markAndUpdate(m_verticalUpdateSongEditor);
     }
@@ -723,7 +723,7 @@ void EditComponent::valueTreeChildRemoved(juce::ValueTree &parent, juce::ValueTr
     }
     if (c.hasType(te::IDs::AUTOMATIONCURVE))
     {
-        GUIHelpers::log(c.toXmlString());
+        NS_LOG_DEBUG(edit, "automation curve removed\n" + c.toXmlString());
         markAndUpdate(m_updateTracks);
         markAndUpdate(m_verticalUpdateSongEditor);
     }
@@ -950,27 +950,27 @@ void EditComponent::duplicateSelectedTracks()
 
 bool EditComponent::perform(const juce::ApplicationCommandTarget::InvocationInfo &info)
 {
-    GUIHelpers::log("EditComponent perform commandID: ", info.commandID);
+    NS_LOG_DEBUG(workflow, "EditComponent command invoked: id=" + juce::String(static_cast<int>(info.commandID)));
 
     switch (info.commandID)
     {
     // send NoteOn
     case KeyPressCommandIDs::deleteSelectedClips:
     {
-        GUIHelpers::log("deleteSelectedClips Outer");
+        NS_LOG_DEBUG(edit, "delete selection requested");
         if (m_songEditor.getTracksWithSelectedTimeRange().size() > 0)
         {
-            GUIHelpers::log("deleteSelectedTimeRange");
+            NS_LOG_INFO(edit, "deleting selected time range");
             m_songEditor.deleteSelectedTimeRange();
         }
         else if (hasSelectedClips())
         {
-            GUIHelpers::log("deleteSelectedClips");
+            NS_LOG_INFO(edit, "deleting selected clips");
             EngineHelpers::deleteSelectedClips(m_editViewState);
         }
         else if (hasSelectedTracks())
         {
-            GUIHelpers::log("deleteSelectedTracks");
+            NS_LOG_INFO(edit, "deleting selected tracks from EditComponent");
             deleteSelectedTracks();
         }
         break;
@@ -992,14 +992,14 @@ bool EditComponent::perform(const juce::ApplicationCommandTarget::InvocationInfo
         m_songEditor.renderSelectionToNewTrack();
         break;
     case KeyPressCommandIDs::transposeClipUp:
-        GUIHelpers::log("perform: transposeClipUp");
+        NS_LOG_INFO(edit, "transposing selected clips up");
         m_songEditor.transposeSelectedClips(+1.f);
         break;
     case KeyPressCommandIDs::transposeClipDown:
         m_songEditor.transposeSelectedClips(-1.f);
         break;
     case KeyPressCommandIDs::reverseClip:
-        GUIHelpers::log("reverse!!!!");
+        NS_LOG_INFO(edit, "reversing selected clips");
         m_songEditor.reverseSelectedClips();
         break;
     default:
@@ -1240,5 +1240,5 @@ void EditComponent::sendAllNotedOff()
         for (int i = 1; i <= 16; ++i)
             track->injectLiveMidiMessage(juce::MidiMessage::allNotesOff(i), {});
 
-    GUIHelpers::log("EditComponent: ", "All notes off!");
+    NS_LOG_INFO(transport, "all notes off sent to audio tracks");
 }

--- a/App/src/FileBrowser.cpp
+++ b/App/src/FileBrowser.cpp
@@ -126,7 +126,7 @@ void FileBrowserComponent::setDirecory(const juce::File &dir)
 {
     if (dir.exists() && dir.isDirectory())
     {
-        GUIHelpers::log("FileBrowserComponent::setDirecory(): ");
+        NS_LOG_INFO(filesystem, "file browser directory set: " + dir.getFullPathName());
         m_currentPathField.setDir(dir);
         setFileList(dir.findChildFiles(juce::File::TypesOfFileToFind::findFilesAndDirectories, false));
     }
@@ -201,7 +201,7 @@ void FileBrowserComponent::changeListenerCallback(juce::ChangeBroadcaster *sourc
     BrowserBaseComponent::changeListenerCallback(source);
     if (source == &m_currentPathField)
     {
-        GUIHelpers::log("FileBrowserComponent::setDir()");
+        NS_LOG_DEBUG(filesystem, "file browser path field changed");
         setDirecory(m_currentPathField.getCurrentPath());
     }
 }

--- a/App/src/Logging.cpp
+++ b/App/src/Logging.cpp
@@ -1,0 +1,90 @@
+#include "Logging.h"
+
+namespace NextStudio::Logging
+{
+namespace
+{
+constexpr bool isDebugLoggingEnabled()
+{
+#if defined(DEBUG) || defined(_DEBUG) || defined(DEBUG_OR_RELWITHDEBINFO)
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool shouldLog(Level level)
+{
+    return level != Level::debug || isDebugLoggingEnabled();
+}
+} // namespace
+
+const char *toString(Level level)
+{
+    switch (level)
+    {
+    case Level::debug:
+        return "debug";
+    case Level::info:
+        return "info";
+    case Level::warn:
+        return "warn";
+    case Level::error:
+        return "error";
+    }
+
+    return "unknown";
+}
+
+const char *toString(Category category)
+{
+    switch (category)
+    {
+    case Category::app:
+        return "app";
+    case Category::ui:
+        return "ui";
+    case Category::viewstate:
+        return "viewstate";
+    case Category::selection:
+        return "selection";
+    case Category::workflow:
+        return "workflow";
+    case Category::project:
+        return "project";
+    case Category::edit:
+        return "edit";
+    case Category::plugins:
+        return "plugins";
+    case Category::filesystem:
+        return "filesystem";
+    case Category::autosave:
+        return "autosave";
+    case Category::transport:
+        return "transport";
+    case Category::engine:
+        return "engine";
+    case Category::setup:
+        return "setup";
+    }
+
+    return "unknown";
+}
+
+void log(Level level, Category category, const juce::String &message, const char *file, int line)
+{
+    if (!shouldLog(level))
+        return;
+
+    juce::String logLine;
+    logLine << juce::Time::getCurrentTime().toString(true, true, true, true)
+            << " [" << toString(level) << "]"
+            << " [" << toString(category) << "] "
+            << message;
+
+    if (file != nullptr && *file != '\0')
+        logLine << " (" << juce::File::createFileWithoutCheckingPath(file).getFileName() << ':' << line << ')';
+
+    juce::Logger::writeToLog(logLine);
+}
+} // namespace NextStudio::Logging

--- a/App/src/LowerRangeComponent.cpp
+++ b/App/src/LowerRangeComponent.cpp
@@ -180,10 +180,10 @@ void LowerRangeComponent::valueTreePropertyChanged(juce::ValueTree &v, const juc
     {
         if (i == IDs::showLowerRange)
         {
-            GUIHelpers::log("LowerRangeComponent valueTreePropertyChanged --------------- ");
+            NS_LOG_DEBUG(viewstate, "lower range track visibility changed");
             if (auto track = te::findTrackForState(m_evs.m_edit, v))
             {
-                GUIHelpers::log("LowerRangeComponent valueTreePropertyChanged ", track->getName());
+                NS_LOG_DEBUG(viewstate, "lower range active track candidate: " + track->getName());
                 if ((bool)v.getProperty(IDs::showLowerRange) == true)
                     syncActiveTrack(true);
             }

--- a/App/src/Main.cpp
+++ b/App/src/Main.cpp
@@ -33,6 +33,7 @@ along with this program.  If not, see https://www.gnu.org/licenses/.
 #include "../JuceLibraryCode/JuceHeader.h"
 #include "MainComponent.h"
 #include "ApplicationViewState.h"
+#include "Logging.h"
 
 //==============================================================================
 class NextStudioApplication : public juce::JUCEApplication
@@ -48,7 +49,7 @@ public:
     //==============================================================================
     void initialise(const juce::String & /*commandLine*/) override
     {
-        juce::Logger::writeToLog("Welcome to " + getApplicationName() + " v" + getApplicationVersion());
+        NS_LOG_INFO(app, "Welcome to " + getApplicationName() + " v" + getApplicationVersion());
         mainWindow.reset(new MainWindow(getApplicationName(), m_applicationState));
     }
 

--- a/App/src/MainComponent.cpp
+++ b/App/src/MainComponent.cpp
@@ -375,8 +375,7 @@ void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationC
 
 bool MainComponent::perform(const juce::ApplicationCommandTarget::InvocationInfo &info)
 {
-
-    GUIHelpers::log("MainComponent::perform() (ApplicationCommandTarget)");
+    NS_LOG_DEBUG(workflow, "command invoked: id=" + juce::String(static_cast<int>(info.commandID)));
     int rootNote = 48;
     switch (info.commandID)
     {
@@ -385,7 +384,7 @@ bool MainComponent::perform(const juce::ApplicationCommandTarget::InvocationInfo
 
         if (auto virMidiIn = EngineHelpers::getVirtualMidiInputDevice(*m_edit))
         {
-            GUIHelpers::log("NAME: ", virMidiIn->getName());
+            NS_LOG_DEBUG(engine, "virtual MIDI note-on routed to device=" + virMidiIn->getName());
             virMidiIn->handleIncomingMidiMessage(juce::MidiMessage::noteOn(1, rootNote + info.commandID - 1, .8f), 0);
             m_pressedKeysForMidiKeyboard.addIfNotAlreadyThere(info.keyPress);
         }
@@ -521,7 +520,7 @@ bool MainComponent::perform(const juce::ApplicationCommandTarget::InvocationInfo
         EngineHelpers::stopPlay(m_editComponent->getEditViewState());
         break;
     case KeyPressCommandIDs::toggleRecord:
-        std::cout << "toggleRecord" << std::endl;
+        NS_LOG_INFO(transport, "toggle record requested");
         EngineHelpers::toggleRecord(m_editComponent->getEditViewState());
         break;
     case KeyPressCommandIDs::loopToggle:
@@ -547,10 +546,8 @@ bool MainComponent::perform(const juce::ApplicationCommandTarget::InvocationInfo
         break;
     case KeyPressCommandIDs::debugOutputEdit:
     {
-        std::cout << "DEBUG EDIT: " << juce::Time::getCurrentTime().toString(true, true, true, true) << std::endl;
-        std::cout << "=================================================================================" << std::endl;
         auto editString = m_edit->state.toXmlString();
-        std::cout << editString << std::endl;
+        NS_LOG_DEBUG(edit, "edit state dump requested\n" + editString);
 
         break;
     }
@@ -645,7 +642,7 @@ void MainComponent::changeListenerCallback(juce::ChangeBroadcaster *source)
     {
         if (m_editViewState->m_applicationState.m_exclusiveMidiFocusEnabled)
         {
-            GUIHelpers::log("MainComponent: selectionManager changed, calling setMidiInputFocusToSelection.");
+            NS_LOG_DEBUG(selection, "selection changed; updating exclusive MIDI focus");
             EngineHelpers::setMidiInputFocusToSelection(*m_editViewState);
         }
     }
@@ -659,7 +656,7 @@ void MainComponent::openValidStartEdit()
     auto f = Helpers::findRecentEdit(m_tempDir);
     if (f.existsAsFile())
     {
-        GUIHelpers::log("MainComponent: found Temp file:" + f.getFullPathName());
+        NS_LOG_WARN(autosave, "recovery file found: " + f.getFullPathName());
         auto result = juce::AlertWindow::showOkCancelBox(juce::AlertWindow::QuestionIcon, "Restore crashed project?", "It seems, NextStudio is crashed last time. Do you want to restore the last session?", "Yes", "No");
         if (result)
         {

--- a/App/src/ModifierViewComponent.cpp
+++ b/App/src/ModifierViewComponent.cpp
@@ -70,7 +70,7 @@ void ModifierViewComponent::DragHandle::draggedOntoAutomatableParameterTarget(co
     {
         if (param->getOwnerID() == m_modifier->itemID)
         {
-            GUIHelpers::log("Can not connect modifier to its own parameters");
+            NS_LOG_WARN(plugins, "modifier connection rejected: modifier cannot target its own parameters");
             getParentComponent()->repaint();
 
             if (auto *rackView = findParentComponentOfClass<PluginChainView>())

--- a/App/src/PluginBrowser.cpp
+++ b/App/src/PluginBrowser.cpp
@@ -265,7 +265,7 @@ void PluginSettings::changeListenerCallback(juce::ChangeBroadcaster *source)
     }
     else if (dynamic_cast<juce::KnownPluginList *>(source))
     {
-        GUIHelpers::log("Liste changed");
+        NS_LOG_DEBUG(plugins, "known plugin list changed; refreshing browser");
         m_listbox.updateContent();
 
         if (isShowing())

--- a/App/src/PluginChainItemView.cpp
+++ b/App/src/PluginChainItemView.cpp
@@ -78,7 +78,7 @@ PluginChainItemView::PluginChainItemView(EditViewState &evs, te::Track::Ptr t, t
     addAndMakeVisible(name);
     name.setInterceptsMouseClicks(false, true);
     name.setVisible(false);
-    GUIHelpers::log("PLUGIN TYPE: ", m_plugin->getPluginType());
+    NS_LOG_DEBUG(plugins, "creating plugin chain item view for type=" + m_plugin->getPluginType());
 
     if (m_plugin->getPluginType() == "volume")
     {
@@ -138,14 +138,14 @@ PluginChainItemView::PluginChainItemView(EditViewState &evs, te::Track::Ptr t, t
     }
     else if (m_plugin->getPluginType() == te::SamplerPlugin::xmlTypeName)
     {
-        GUIHelpers::log(m_plugin->getPluginType());
+        NS_LOG_DEBUG(plugins, "instantiating sampler plugin UI for type=" + m_plugin->getPluginType());
         if (auto *sampler = dynamic_cast<te::SamplerPlugin *>(p.get()))
         {
             m_pluginComponent = std::make_unique<DrumSamplerView>(evs, *sampler);
         }
         else
         {
-            GUIHelpers::log("ERROR: Plugin claims to be sampler but dynamic_cast failed!");
+            NS_LOG_ERROR(plugins, "plugin reports sampler type but sampler cast failed");
         }
     }
     else

--- a/App/src/PluginScanner.cpp
+++ b/App/src/PluginScanner.cpp
@@ -182,7 +182,7 @@ void PluginScanner::startScan()
     }
     else if (m_propertiesToUse != nullptr)
     {
-        GUIHelpers::log("setLastSearchPath");
+        NS_LOG_DEBUG(plugins, "persisting last plugin scan path");
         setLastSearchPath(*m_propertiesToUse, m_formatToScan, m_pathList.getPath());
         m_propertiesToUse->saveIfNeeded();
     }

--- a/App/src/PresetHelpers.cpp
+++ b/App/src/PresetHelpers.cpp
@@ -73,12 +73,12 @@ bool tryLoadInitPreset(PluginPresetInterface &interface)
             }
             else
             {
-                GUIHelpers::log("Error loading init preset: Type mismatch. Expected " + interface.getPluginTypeName());
+                NS_LOG_WARN(plugins, "init preset type mismatch; expected " + interface.getPluginTypeName());
             }
         }
         else
         {
-            GUIHelpers::log("Error parsing init preset XML for " + interface.getPluginTypeName());
+            NS_LOG_ERROR(plugins, "failed to parse init preset XML for " + interface.getPluginTypeName());
         }
     }
     return false;

--- a/App/src/PresetManagerComponent.cpp
+++ b/App/src/PresetManagerComponent.cpp
@@ -262,14 +262,14 @@ void PresetManagerComponent::applyPresetFile(const juce::File &presetFile)
     {
         if (!xml->hasTagName("PLUGIN"))
         {
-            GUIHelpers::log("PresetManagerComponent: Root element is not <PLUGIN> in " + presetFile.getFileName());
+            NS_LOG_WARN(plugins, "preset rejected: root element is not <PLUGIN> in " + presetFile.getFileName());
             return;
         }
 
         auto presetState = juce::ValueTree::fromXml(*xml);
         if (!m_pluginInterface.applyPresetState(presetState))
         {
-            GUIHelpers::log("PresetManagerComponent: Preset type mismatch or invalid format in " + presetFile.getFileName());
+            NS_LOG_WARN(plugins, "preset rejected: type mismatch or invalid format in " + presetFile.getFileName());
             return;
         }
 
@@ -279,7 +279,7 @@ void PresetManagerComponent::applyPresetFile(const juce::File &presetFile)
         return;
     }
 
-    GUIHelpers::log("PresetManagerComponent: Failed to parse XML in " + presetFile.getFullPathName());
+    NS_LOG_ERROR(plugins, "failed to parse preset XML: " + presetFile.getFullPathName());
 }
 
 juce::Array<juce::File> PresetManagerComponent::getAvailablePresetFiles()

--- a/App/src/SampleBrowser.cpp
+++ b/App/src/SampleBrowser.cpp
@@ -143,7 +143,7 @@ void SampleBrowserComponent::previewSampleFile(const juce::File &file)
 
 void SampleBrowserComponent::sortList(int selectedID)
 {
-    GUIHelpers::log("SELECTED ID: ", selectedID);
+    NS_LOG_DEBUG(filesystem, "sample browser sort mode selected: id=" + juce::String(selectedID));
     juce::Array<juce::File> fileList;
 
     for (auto f : m_contentList)

--- a/App/src/SongEditorView.cpp
+++ b/App/src/SongEditorView.cpp
@@ -200,7 +200,7 @@ bool SongEditorView::isInterestedInDragSource(const SourceDetails &dragSourceDet
     if (auto fileTreeComp = dynamic_cast<juce::FileTreeComponent *>(dragSourceDetails.sourceComponent.get()))
         return true;
 
-    GUIHelpers::log(dragSourceDetails.description.toString());
+    NS_LOG_DEBUG(ui, "SongEditor drag source: " + dragSourceDetails.description.toString());
 
     if (dragSourceDetails.description == "FileBrowser")
     {
@@ -621,9 +621,9 @@ void SongEditorView::duplicateSelectedClipsOrTimeRange()
         auto range = te::getTimeRangeForSelectedItems(selectedClips);
         auto delta = range.getLength().inSeconds();
 
-        GUIHelpers::log("moving Clips.");
+        NS_LOG_INFO(edit, "duplicating selected clips");
         moveSelectedClips(true, delta, 0);
-        GUIHelpers::log("Clips moved.");
+        NS_LOG_DEBUG(edit, "selected clips duplicated");
     }
 }
 
@@ -1040,14 +1040,13 @@ void SongEditorView::buildRecordingClips(te::Track::Ptr track)
 
 void SongEditorView::logMousePositionInfo()
 {
-    GUIHelpers::log("------------------------------------------------------------");
-    GUIHelpers::log("ToolMode    : ", (int)m_toolMode);
-    GUIHelpers::log("Track       : ", m_hoveredTrack != nullptr);
-    if (m_hoveredTrack)
-    {
-        GUIHelpers::log("Track : ", m_hoveredTrack->getName());
-    }
+    juce::String message = "mouse context: toolMode=" + juce::String(static_cast<int>(m_toolMode))
+        + ", hasHoveredTrack=" + NextStudio::Logging::toLogString(m_hoveredTrack != nullptr);
 
+    if (m_hoveredTrack)
+        message << ", hoveredTrack=" << m_hoveredTrack->getName();
+
+    NS_LOG_DEBUG(ui, message);
     repaint();
 }
 

--- a/App/src/SoundEditorPanel.cpp
+++ b/App/src/SoundEditorPanel.cpp
@@ -27,7 +27,7 @@ SoundEditorPanel::SoundEditorPanel(te::SamplerPlugin &plugin, te::Edit &edit, Ap
       m_appViewState(appViewState),
       m_samplerPlugin(plugin)
 {
-    GUIHelpers::log("SoundEditorPanel: constructor");
+    NS_LOG_DEBUG(plugins, "SoundEditorPanel constructed");
 
     // Create gain slider with range -48.0 to 48.0
     gainValue.setValue(-48.0);
@@ -70,7 +70,7 @@ SoundEditorPanel::SoundEditorPanel(te::SamplerPlugin &plugin, te::Edit &edit, Ap
 
 SoundEditorPanel::~SoundEditorPanel()
 {
-    GUIHelpers::log("SoundEditorPanel: destructor");
+    NS_LOG_DEBUG(plugins, "SoundEditorPanel destroyed");
     gainValue.removeListener(this);
     panValue.removeListener(this);
     openEndedButton.removeListener(this);

--- a/App/src/TrackHeadComponent.cpp
+++ b/App/src/TrackHeadComponent.cpp
@@ -487,7 +487,7 @@ TrackHeaderComponent::TrackHeaderComponent(EditViewState &evs, te::Track::Ptr t)
             m_volumeKnob->setSkewFactorFromMidPoint(1.0f);
             m_volumeKnob->setSliderStyle(juce::Slider::RotaryVerticalDrag);
             m_volumeKnob->setTextBoxStyle(juce::Slider::NoTextBox, false, 0, false);
-            GUIHelpers::log("Master header: volume knob created");
+            NS_LOG_DEBUG(ui, "master track header volume knob created");
         }
     }
 
@@ -671,7 +671,7 @@ void TrackHeaderComponent::showPopupMenu(tracktion_engine::Track *at)
     {
         if (auto aut = dynamic_cast<te::AudioTrack *>(m_track.get()))
         {
-            GUIHelpers::log("TrackHeadComponent.cpp : enable input");
+            NS_LOG_INFO(ui, "toggling input monitoring for track: " + m_track->getName());
             bool ticked = EngineHelpers::isInputMonitoringEnabled(*aut);
             EngineHelpers::enableInputMonitoring(*aut, !ticked);
         }

--- a/App/src/TrackHeightManager.cpp
+++ b/App/src/TrackHeightManager.cpp
@@ -305,7 +305,7 @@ void TrackHeightManager::setAutomationHeight(const tracktion_engine::Automatable
 
     trackInfo->automationParameterHeights[ap] = height;
 
-    GUIHelpers::log("ParameterHeight set to: ", height);
+    NS_LOG_DEBUG(viewstate, "automation parameter height set: " + juce::String(height));
     triggerFlashState();
 }
 tracktion::Track::Ptr TrackHeightManager::getTrackFromID(tracktion_engine::Edit &edit, const tracktion_engine::EditItemID &id)
@@ -355,7 +355,7 @@ tracktion_engine::AutomatableParameter::Ptr TrackHeightManager::findAutomatableP
 
 void TrackHeightManager::flashStateFromTrackInfos()
 {
-    GUIHelpers::log("Update State from TrackInfos");
+    NS_LOG_DEBUG(viewstate, "flushing track height state from cached track infos");
     // Sort TrackInfos by hierarchy depth so parent folders are processed first
     TrackHeightInfoComparator comparator;
     trackInfos.sort(comparator);
@@ -388,7 +388,7 @@ void TrackHeightManager::flashStateFromTrackInfos()
         {
             if (ap)
             {
-                GUIHelpers::log("SAVE HEIGHT TO STATE/  HEIGHT: ", height);
+                NS_LOG_DEBUG(viewstate, "saving automation lane height to state: " + juce::String(height));
                 if ((int)ap->getCurve().state.getProperty(tracktion_engine::IDs::height, height) != height)
                     ap->getCurve().state.setProperty(tracktion_engine::IDs::height, height, nullptr);
             }
@@ -412,7 +412,7 @@ void TrackHeightManager::setTrackHeight(tracktion_engine::Track *track, int heig
 void TrackHeightManager::triggerFlashState()
 {
     sendChangeMessage();
-    GUIHelpers::log("TrackHeightManager: flash state triggered");
+    NS_LOG_DEBUG(viewstate, "track height state flush scheduled");
     pendingFlashState = true;
     startTimer(100);
 }
@@ -420,10 +420,10 @@ void TrackHeightManager::timerCallback()
 {
     stopTimer();
 
-    GUIHelpers::log("TrackHeightManager: timer callback");
+    NS_LOG_DEBUG(viewstate, "track height flush timer fired");
     if (pendingFlashState)
     {
-        GUIHelpers::log("TrackHeightManager: pending state: true");
+        NS_LOG_DEBUG(viewstate, "pending track height state detected; flushing now");
         flashStateFromTrackInfos();
         pendingFlashState = false;
     }
@@ -442,7 +442,7 @@ int TrackHeightManager::calculateHierarchyDepth(tracktion_engine::Track *track)
 
 void TrackHeightManager::regenerateTrackHeightsFromStates(const juce::Array<tracktion_engine::Track *> &allTracks)
 {
-    GUIHelpers::log("Update TrackInfo from State");
+    NS_LOG_DEBUG(viewstate, "rebuilding track height cache from edit state");
 
     trackInfos.clear();
 

--- a/App/src/TrackListView.cpp
+++ b/App/src/TrackListView.cpp
@@ -234,12 +234,12 @@ void TrackListView::getCommandInfo(juce::CommandID commandID, juce::ApplicationC
 bool TrackListView::perform(const juce::ApplicationCommandTarget::InvocationInfo &info)
 {
 
-    GUIHelpers::log("TrackListView perform");
+    NS_LOG_DEBUG(workflow, "TrackListView command invoked: id=" + juce::String(static_cast<int>(info.commandID)));
     switch (info.commandID)
     {
     case KeyPressCommandIDs::deleteSelectedTracks:
     {
-        GUIHelpers::log("deleteSelectedTracks");
+        NS_LOG_INFO(edit, "deleting selected tracks from TrackListView");
 
         for (auto t : m_editViewState.m_selectionManager.getItemsOfType<te::Track>())
         {

--- a/App/src/Utilities.cpp
+++ b/App/src/Utilities.cpp
@@ -53,11 +53,11 @@ juce::String Helpers::getStringOrDefault(const juce::String &stringToTest, const
 
 juce::File Helpers::findRecentEdit(const juce::File &dir)
 {
-    GUIHelpers::log("Utilities: search for temp file: " + dir.getFullPathName());
+    NS_LOG_DEBUG(filesystem, "searching for temp edit in: " + dir.getFullPathName());
     auto files = dir.findChildFiles(juce::File::findFiles, false, "*.nextTemp");
     if (files.size() > 0)
     {
-        GUIHelpers::log("Utilities: found at least 1 File");
+        NS_LOG_DEBUG(filesystem, "found temp edit candidates");
         files.sort();
         return files.getLast();
     }
@@ -1188,12 +1188,12 @@ void EngineHelpers::renderEditToFile(EditViewState &evs, juce::File renderFile, 
 {
     if (!renderFile.create())
     {
-        juce::Logger::writeToLog("Error: Could not create file. Check permissions.");
+        NS_LOG_ERROR(filesystem, "could not create render file: check permissions for " + renderFile.getFullPathName());
         return;
     }
     else
     {
-        GUIHelpers::log("File exists");
+        NS_LOG_DEBUG(filesystem, "render file prepared: " + renderFile.getFullPathName());
     }
 
     if (range == tracktion::TimeRange{})
@@ -1201,7 +1201,7 @@ void EngineHelpers::renderEditToFile(EditViewState &evs, juce::File renderFile, 
 
     if (te::getAudioTracks(evs.m_edit).size() == 0)
     {
-        juce::Logger::writeToLog("Error: The edit contains no tracks.");
+        NS_LOG_WARN(edit, "render aborted: edit contains no audio tracks");
         return;
     }
 
@@ -1210,7 +1210,7 @@ void EngineHelpers::renderEditToFile(EditViewState &evs, juce::File renderFile, 
     if (tracksToDo.isZero())
     {
         if (!writeSilentRenderFile(renderFile, range, evs.m_edit.engine))
-            juce::Logger::writeToLog("Error: Could not create silent render file.");
+            NS_LOG_ERROR(filesystem, "could not create silent render file: " + renderFile.getFullPathName());
 
         return;
     }
@@ -1350,7 +1350,7 @@ void EngineHelpers::setMidiInputFocusToSelection(EditViewState &evs)
 
     if (contextReallocNeeded)
     {
-        GUIHelpers::log("Utilities: setMidiInputFocusToSelection - Targets updated, restarting playback.");
+        NS_LOG_INFO(selection, "MIDI input targets updated from selection; restarting playback");
         evs.m_edit.restartPlayback();
     }
 }
@@ -1363,7 +1363,7 @@ te::MidiInputDevice *EngineHelpers::getVirtualMidiInputDevice(te::Edit &edit)
 
     for (const auto instance : edit.getAllInputDevices())
     {
-        DBG(instance->getInputDevice().getName());
+        NS_LOG_DEBUG(engine, "available MIDI input device: " + instance->getInputDevice().getName());
 
         if (instance->getInputDevice().getDeviceType() == te::InputDevice::virtualMidiDevice && instance->getInputDevice().getName() == name)
             return dynamic_cast<te::MidiInputDevice *>(&instance->getInputDevice());
@@ -2183,7 +2183,7 @@ tracktion_engine::WaveAudioClip::Ptr EngineHelpers::loadAudioFileToTrack(EditVie
     auto newClip = te::WaveAudioClip::Ptr(dynamic_cast<te::WaveAudioClip *>(result.clips.getFirst().get()));
     if (newClip != nullptr)
     {
-        GUIHelpers::log("loading : " + file.getFullPathName());
+        NS_LOG_INFO(filesystem, "loading audio file to track: " + file.getFullPathName());
         newClip->setAutoTempo(false);
         newClip->setAutoPitch(false);
     }
@@ -2223,7 +2223,7 @@ void EngineHelpers::refreshRelativePathsToNewEditFile(EditViewState &evs, const 
 
 void EngineHelpers::play(EditViewState &evs)
 {
-    GUIHelpers::log("play");
+    NS_LOG_INFO(transport, "play requested");
     auto &transport = evs.m_edit.getTransport();
 
     if (transport.isPlaying())
@@ -2247,13 +2247,13 @@ void EngineHelpers::stopPlay(EditViewState &evs)
         transport.setPosition(tracktion::TimePosition::fromSeconds(static_cast<double>(evs.m_playHeadStartTime)));
         evs.setNewStartAndZoom("SongEditor", 0.0);
         transport.stop(false, true);
-        GUIHelpers::log("EngineHelpers::stopPlay: stop and Device cleared.");
+        NS_LOG_INFO(transport, "playback stopped and preview device cleared");
     }
     else
     {
         transport.stop(false, false);
         transport.setPosition(tracktion::TimePosition::fromSeconds(static_cast<double>(evs.m_playHeadStartTime)));
-        GUIHelpers::log("EngineHelpers::stopPlay: stop.");
+        NS_LOG_INFO(transport, "playback stopped");
     }
 }
 void EngineHelpers::togglePlay(EditViewState &evs)
@@ -2345,7 +2345,7 @@ void EngineHelpers::toggleSnap(EditViewState &evs)
 
 void EngineHelpers::toggleMetronome(te::Edit &edit)
 {
-    GUIHelpers::log("toggle metronome");
+    NS_LOG_INFO(transport, "toggle metronome requested");
     edit.clickTrackEnabled = !edit.clickTrackEnabled;
 }
 
@@ -2378,7 +2378,7 @@ void EngineHelpers::armTrack(te::AudioTrack &t, bool arm, int position)
     {
         if (te::isOnTargetTrack(*instance, t, position))
         {
-            GUIHelpers::log("Utilities.cpp: arm Track");
+            NS_LOG_INFO(edit, "arming selected MIDI track for recording");
             instance->setRecordingEnabled(t.itemID, arm);
         }
     }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,141 @@
+# Logging Guide
+
+## Goal
+
+Logging in NextStudio should primarily make the application's own behavior visible:
+
+- GUI state
+- user actions
+- view state changes
+- project/edit workflow
+- plugin, file, and render actions
+- relevant edit/engine context
+
+The goal is **not** to fully mirror internal `tracktion_engine` details.
+
+## Central API
+
+Only use the central logger from:
+
+- `App/Source/Utilities/Logging.h`
+
+Macros:
+
+- `NS_LOG_DEBUG(category, message)`
+- `NS_LOG_INFO(category, message)`
+- `NS_LOG_WARN(category, message)`
+- `NS_LOG_ERROR(category, message)`
+
+## Output and build behavior
+
+The logger emits one line through `juce::Logger::writeToLog(...)` with this shape:
+
+```text
+<local timestamp> [<level>] [<category>] <message> (<source-file>:<line>)
+```
+
+The active JUCE logger decides the final sink. Without a custom logger, JUCE uses its platform-default diagnostic output. Logging must never be used as the debug-shell response transport; shell responses remain on stdout and diagnostic output should be routed separately by launchers.
+
+`debug` messages are compiled in but filtered unless the build defines `DEBUG`, `_DEBUG`, or `DEBUG_OR_RELWITHDEBINFO`. The project defines `DEBUG_OR_RELWITHDEBINFO` for Debug and RelWithDebInfo builds. `info`, `warn`, and `error` are emitted in all build types.
+
+## Categories
+
+Currently available categories:
+
+- `app`
+- `ui`
+- `viewstate`
+- `selection`
+- `workflow`
+- `project`
+- `edit`
+- `plugins`
+- `filesystem`
+- `autosave`
+- `transport`
+- `engine`
+- `setup`
+
+## Ground Rules
+
+### 1. Log app-first
+
+Prefer logs that explain:
+
+- what the user did
+- which visible state changed
+- which action NextStudio derived from it
+
+### 2. Use engine information as context
+
+Only log `engine` or `edit` information when it helps explain app or GUI behavior.
+
+### 3. Write semantic messages
+
+Bad:
+
+- `"button"`
+- `"play"`
+- `"Liste changed"`
+
+Better:
+
+- `"browser path up button pressed"`
+- `"play requested"`
+- `"known plugin list changed; refreshing browser"`
+
+### 4. Choose the right log level
+
+- `debug`: technical flow details, frequent state changes, or large diagnostic state
+- `info`: normal, important actions
+- `warn`: unusual but tolerable situations
+- `error`: failures or broken operations
+
+Never emit complete edit XML, plugin state, credentials, environment contents, or user media data at `info` level. Prefer identifiers and compact summaries. Large state dumps belong in explicitly requested artifacts and may only be referenced by path in logs.
+
+## What should be logged
+
+- transport actions
+- file and render operations
+- preset and plugin actions
+- selection and view state transitions
+- recovery / autosave
+- failed load operations
+- unexpected but recoverable situations
+
+## What should be avoided
+
+- unstructured debug text
+- repeated redundant logs without added value
+- deep Tracktion internals without app relevance
+- very frequent hot-path logs without real diagnostic value
+
+## Examples
+
+```cpp
+NS_LOG_INFO(transport, "play requested");
+NS_LOG_WARN(filesystem, "render aborted: output file already exists");
+NS_LOG_ERROR(plugins, "failed to parse preset XML: " + presetFile.getFullPathName());
+NS_LOG_DEBUG(viewstate, "rebuilding track height cache from edit state");
+```
+
+## Threading and performance
+
+`log(...)` may be called from application worker threads, subject to the active JUCE logger's threading contract. Do not add logging to real-time audio callbacks or other hot paths: formatting allocates strings and the sink may block. Avoid high-frequency duplicate messages and never use logging as synchronization.
+
+## Adding a category
+
+Add the enum value in `App/include/Logging.h`, add its stable lowercase spelling in `Logging.cpp`, document it here, and add or update a focused test when logging tests are introduced. Existing category spellings are part of diagnostics consumed by users and tools and should not be renamed casually.
+
+## Legacy code
+
+Do not introduce again:
+
+- `std::cout`
+- `DBG(...)`
+- direct `juce::Logger::writeToLog(...)` calls outside `Logging.cpp`
+- new ad-hoc `GUIHelpers::log(...)` usage
+
+## Note
+
+`GUIHelpers::log(...)` only remains as a compatibility path for older code. New or refactored code should directly use the `NS_LOG_*` macros.


### PR DESCRIPTION
## Summary
- introduce the central `NS_LOG_*` logging API
- migrate existing application call sites away from ad-hoc logging
- document categories, levels, output policy, and migration rules

This separates the logging migration from `feature/debug-system-agent`.

Relates to #16.
Closes #38.